### PR TITLE
delint jquery.raty.js

### DIFF
--- a/lib/generators/ratyrate/templates/jquery.raty.js
+++ b/lib/generators/ratyrate/templates/jquery.raty.js
@@ -32,17 +32,17 @@
 
 				$this.data('settings', self.opt);
 
-				if (typeof self.opt.number == 'function') {
+				if (typeof self.opt.number === 'function') {
 					self.opt.number = self.opt.number.call(self);
 				} else {
-					self.opt.number = methods.between(self.opt.number, 0, 20)
+					self.opt.number = methods.between(self.opt.number, 0, 20);
 				}
 
-				if (self.opt.path.substring(self.opt.path.length - 1, self.opt.path.length) != '/') {
+				if (self.opt.path.substring(self.opt.path.length - 1, self.opt.path.length) !== '/') {
 					self.opt.path += '/';
 				}
 
-				if (typeof self.opt.score == 'function') {
+				if (typeof self.opt.score === 'function') {
 					self.opt.score = self.opt.score.call(self);
 				}
 
@@ -82,7 +82,7 @@
 				if (self.opt.cancel) {
 					self.cancel = $('<img />', { src: self.opt.path + self.opt.cancelOff, alt: 'x', title: self.opt.cancelHint, 'class': 'raty-cancel' });
 
-					if (self.opt.cancelPlace == 'left') {
+					if (self.opt.cancelPlace === 'left') {
 						$this.prepend('&#160;').prepend(self.cancel);
 					} else {
 						$this.append('&#160;').append(self.cancel);
@@ -145,8 +145,8 @@
 					self.score.removeAttr('value');
 
 					if (self.opt.click) {
-			          self.opt.click.call(self, null, evt);
-			        }
+						self.opt.click.call(self, null, evt);
+					}
 				});
 			}
 
@@ -155,7 +155,7 @@
 
 				if (self.opt.half) {
 					var position	= parseFloat((evt.pageX - $(this).offset().left) / self.opt.size),
-						diff		= (position > .5) ? 1 : .5;
+						diff		= (position > 0.5) ? 1 : 0.5;
 
 					value = parseFloat(this.alt) - 1 + diff;
 
@@ -236,7 +236,7 @@
 					star = self.opt.iconRange[count];
 
 					if (self.opt.single) {
-						icon = (i == score) ? (star.on || self.opt.starOn) : (star.off || self.opt.starOff);
+						icon = (i === score) ? (star.on || self.opt.starOn) : (star.off || self.opt.starOff);
 					} else {
 						icon = (i <= score) ? (star.on || self.opt.starOn) : (star.off || self.opt.starOff);
 					}
@@ -245,12 +245,12 @@
 						$star.attr('src', self.opt.path + icon);
 					}
 
-					if (i == star.range) {
+					if (i === star.range) {
 						count++;
 					}
 				} else {
 					if (self.opt.single) {
-						icon = (i == score) ? self.opt.starOn : self.opt.starOff;
+						icon = (i === score) ? self.opt.starOn : self.opt.starOff;
 					} else {
 						icon = (i <= score) ? self.opt.starOn : self.opt.starOff;
 					}
@@ -354,7 +354,7 @@
 			if (this.opt.target) {
 				var $target = $(this.opt.target);
 
-				if ($target.length == 0) {
+				if ($target.length === 0) {
 					methods.error.call(this, 'target selector invalid or missing!');
 				}
 
@@ -363,7 +363,7 @@
 				if (!isKeep || score === undefined) {
 					score = this.opt.targetText;
 				} else {
-					if (this.opt.targetType == 'hint') {
+					if (this.opt.targetType === 'hint') {
 						score = (score === null && this.opt.cancel)
 								? this.opt.cancelHint
 								: this.opt.hints[Math.ceil(score - 1)];
@@ -391,7 +391,7 @@
 		}, showHalf: function(score) {
 			var diff = (score - Math.floor(score)).toFixed(1);
 
-			if (diff > 0 && diff < .6) {
+			if (diff > 0 && diff < 0.6) {
 				this.stars.eq(Math.ceil(score) - 1).attr('src', this.opt.path + this.opt.starHalf);
 			}
 		}, initialize: function(score) {
@@ -443,7 +443,7 @@
 		number			: 5,
 		path			: 'img/',
 		precision		: false,
-		round			: { down: .25, full: .6, up: .76 },
+		round			: { down: 0.25, full: 0.6, up: 0.76 },
 		readOnly		: false,
 		score			: undefined,
 		scoreName		: 'score',


### PR DESCRIPTION
CodeClimate drops my project from A to D when I add ratyrate,
all due to jquery.raty.js.
This is a fix of all the lint errors that CodeClimate complains about,
except for the 'bad line breaks' inside the ternary operators.
I am unable to run the test suite -
I am getting a complaint about not being able to find rspec/auto.
So please test before merging!
