### PR TITLE
fix stars not display with turbolinks

### DIFF
--- a/lib/generators/ratyrate/templates/ratyrate.js.erb
+++ b/lib/generators/ratyrate/templates/ratyrate.js.erb
@@ -62,4 +62,4 @@ function initstars(){
 };
 
 $(document).ready(initstars);
-$(document).on('page:change',initstarts);
+$(document).on('page:change',initstars);


### PR DESCRIPTION
still backwards compatible of course
