### PR TITLE
Fix error when reflecting on associations.

### DIFF
--- a/lib/ratyrate/model.rb
+++ b/lib/ratyrate/model.rb
@@ -129,7 +129,7 @@ module Ratyrate
                                               :class_name => "Rate",
                                               :as => :rateable
 
-        has_many "#{dimension}_raters".to_sym, :through => "#{dimension}_rates", :source => :rater
+        has_many "#{dimension}_raters".to_sym, :through => :"#{dimension}_rates", :source => :rater
 
         has_one "#{dimension}_average".to_sym, -> { where dimension: dimension.to_s },
                                               :as => :cacheable, :class_name => "RatingCache",


### PR DESCRIPTION
- `:through` values should be symbols (see
  https://github.com/rails/rails/blob/4-1-stable/activerecord/lib/active_record/reflection.rb#L25),
- this was causing errors in ActiveAdmin.
- fixes #46.
