### PR TITLE
data-cancel should be treated as boolean value, not string

### DIFF
--- a/lib/generators/ratyrate/templates/ratyrate.js.erb
+++ b/lib/generators/ratyrate/templates/ratyrate.js.erb
@@ -9,6 +9,7 @@ function initstars(){
     var $half     = ($(this).attr('data-enable-half') == 'true');
     var $halfShow = ($(this).attr('data-half-show') == 'true');
     var $single   = ($(this).attr('data-single') == 'true');
+    var $cancel   = ($(this).attr('data-cancel') == 'true');
     $(this).raty({
       score: function() {
         return $(this).attr('data-rating')
@@ -23,7 +24,7 @@ function initstars(){
       starOn:      $(this).attr('data-star-on'),
       starOff:     $(this).attr('data-star-off'),
       starHalf:    $(this).attr('data-star-half'),
-      cancel:      $(this).attr('data-cancel'),
+      cancel:      $cancel,
       cancelPlace: $(this).attr('data-cancel-place'),
       cancelHint:  $(this).attr('data-cancel-hint'),
       cancelOn:    $(this).attr('data-cancel-on'),


### PR DESCRIPTION
Hey!

I've spent some time trying to understand why `data-cancel="false"` is ignored. The this is "false" is read as string but compared as boolean. This makes impossible to turn "cancel" feature.

And thank you for your work.