### PR TITLE
Trigger an event when there is a new rating

### DIFF
--- a/lib/generators/ratyrate/templates/ratyrate.js.erb
+++ b/lib/generators/ratyrate/templates/ratyrate.js.erb
@@ -41,6 +41,7 @@ function initstars(){
       click: function(score, evt) {
         var _this = this;
         if (score == null) { score = 0; }
+        $(this).trigger('rated', score)
         $.post('<%= Rails.application.class.routes.url_helpers.rate_path %>',
         {
           score: score,


### PR DESCRIPTION
I'm not sure if I have missed it, but it seems there is no way to get a callback when there has been a new rating. I added a simple `'rated'` event.