### PR TITLE
fix jquery.raty.js not found error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ratyrate (1.2.0.alpha)
+    ratyrate (1.2.2.alpha)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/generators/ratyrate/ratyrate_generator.rb
+++ b/lib/generators/ratyrate/ratyrate_generator.rb
@@ -7,7 +7,7 @@ class RatyrateGenerator < ActiveRecord::Generators::Base
 
   desc "copying jquery.raty files to assets directory ..."
   def copying
-    copy_file 'jquery.raty.js', 'app/assets/javascripts/jquery.raty.js'
+    copy_file 'jquery.raty.js.erb', 'app/assets/javascripts/jquery.raty.js'
     copy_file 'star-on.png', 'app/assets/images/star-on.png'
     copy_file 'star-off.png', 'app/assets/images/star-off.png'
     copy_file 'star-half.png', 'app/assets/images/star-half.png'


### PR DESCRIPTION
On bundle install it gave:
 > error:Could not find "jquery.raty.js" in any of your source paths.