### PR TITLE
add index for migration

### DIFF
--- a/lib/generators/ratyrate/templates/average_cache_migration.rb
+++ b/lib/generators/ratyrate/templates/average_cache_migration.rb
@@ -7,6 +7,8 @@ class CreateAverageCaches < ActiveRecord::Migration
       t.float :avg, :null => false
       t.timestamps
     end
+
+    add_index :average_caches, [:rater_id, :rateable_id, :rateable_type]
   end
 
   def self.down

--- a/lib/generators/ratyrate/templates/overall_average_migration.rb
+++ b/lib/generators/ratyrate/templates/overall_average_migration.rb
@@ -6,6 +6,8 @@ class CreateOverallAverages < ActiveRecord::Migration
       t.float :overall_avg, :null => false
       t.timestamps
     end
+
+    add_index :overall_averages, [:rateable_id, :rateable_type]
   end
 
   def self.down


### PR DESCRIPTION
always add index for foreign key, based [http://rails-bestpractices.com/posts/2010/07/24/always-add-db-index/](url)