### PR TITLE
Fixing migrations for rails 5.2 and turn back on the overall_ratings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 /pkg/*
 

--- a/lib/generators/ratyrate/templates/average_cache_migration.rb
+++ b/lib/generators/ratyrate/templates/average_cache_migration.rb
@@ -1,4 +1,4 @@
-class CreateAverageCaches < ActiveRecord::Migration
+class CreateAverageCaches < ActiveRecord::Migration[5.2]
 
   def self.up
     create_table :average_caches do |t|
@@ -13,6 +13,7 @@ class CreateAverageCaches < ActiveRecord::Migration
 
   def self.down
     drop_table :average_caches
+    remove_index :rating_caches, [:cacheable_id, :cacheable_type]
   end
 
 end

--- a/lib/generators/ratyrate/templates/migration.rb
+++ b/lib/generators/ratyrate/templates/migration.rb
@@ -1,4 +1,4 @@
-class CreateRates < ActiveRecord::Migration
+class CreateRates < ActiveRecord::Migration[5.2]
 
   def self.up
       create_table :rates do |t|
@@ -15,6 +15,8 @@ class CreateRates < ActiveRecord::Migration
 
     def self.down
       drop_table :rates
+      remove_index :rates, :rater_id
+      remove_index :rates, [:rateable_id, :rateable_type]
     end
 
 end

--- a/lib/generators/ratyrate/templates/overall_average_migration.rb
+++ b/lib/generators/ratyrate/templates/overall_average_migration.rb
@@ -1,4 +1,4 @@
-class CreateOverallAverages < ActiveRecord::Migration
+class CreateOverallAverages < ActiveRecord::Migration[5.2]
 
   def self.up
     create_table :overall_averages do |t|

--- a/lib/ratyrate/model.rb
+++ b/lib/ratyrate/model.rb
@@ -64,26 +64,27 @@ module Ratyrate
   end
 
   def overall_avg(user)
-    # avg = OverallAverage.where(rateable_id: self.id)
-    # #FIXME: Fix the bug when the movie has no ratings
-    # unless avg.empty?
-    #   return avg.take.avg unless avg.take.avg == 0
-    # else # calculate average, and save it
-    #   dimensions_count = overall_score = 0
-    #   user.ratings_given.select('DISTINCT dimension').each do |d|
-    #     dimensions_count = dimensions_count + 1
-    #     unless average(d.dimension).nil?
-    #       overall_score = overall_score + average(d.dimension).avg
-    #     end
-    #   end
-    #   overall_avg = (overall_score / dimensions_count).to_f.round(1)
-    #   AverageCache.create! do |a|
-    #     a.rater_id = user.id
-    #     a.rateable_id = self.id
-    #     a.avg = overall_avg
-    #   end
-    #   overall_avg
-    # end
+    avg = OverallAverage.where(rateable_id: self.id)
+    #FIXME: Fix the bug when the movie has no ratings
+    unless avg.empty?
+      return avg.take.avg unless avg.take.avg == 0
+    else # calculate average, and save it
+      dimensions_count = overall_score = 0
+      user.ratings_given.select('DISTINCT dimension').each do |d|
+        dimensions_count = dimensions_count + 1
+        unless average(d.dimension).nil?
+          overall_score = overall_score + average(d.dimension).avg
+        end
+      end
+      overall_avg = (overall_score / dimensions_count).to_f.round(1)
+      AverageCache.create! do |a|
+        a.rater_id = user.id
+        a.rateable_id = self.id
+        a.rateable_type = self.class.to_s
+        a.avg = overall_avg
+      end
+      overall_avg
+    end
   end
 
   # calculates the movie overall average rating for all users


### PR DESCRIPTION
Just a couple things I added locally to make it work on rails 5 and get the averages to show up again.