### PR TITLE
Fix for Directly inheriting from ActiveRecord::Migration is not supported

### DIFF
--- a/lib/generators/ratyrate/ratyrate_generator.rb
+++ b/lib/generators/ratyrate/ratyrate_generator.rb
@@ -36,21 +36,34 @@ class RatyrateGenerator < ActiveRecord::Generators::Base
 
   desc "cacheable rating average migration is creating ..."
   def create_cacheable_migration
-    migration_template "cache_migration.rb", "db/migrate/create_rating_caches.rb"
+    migration_template "cache_migration.rb", "db/migrate/create_rating_caches.rb", migration_version: migration_version
   end
 
   desc "migration is creating ..."
   def create_ratyrate_migration
-    migration_template "migration.rb", "db/migrate/create_rates.rb"
+    migration_template "migration.rb", "db/migrate/create_rates.rb", migration_version: migration_version
   end
 
   desc "average caches migration is creating ..."
   def create_average_caches_migration
-    migration_template "average_cache_migration.rb", "db/migrate/create_average_caches.rb"
+    migration_template "average_cache_migration.rb", "db/migrate/create_average_caches.rb", migration_version: migration_version
   end
 
   desc "overall averages migration is creating ..."
   def create_overall_averages_migration
-    migration_template "overall_average_migration.rb", "db/migrate/create_overall_averages.rb"
+    migration_template "overall_average_migration.rb", "db/migrate/create_overall_averages.rb", migration_version: migration_version
   end
+
+  def rails5?
+    Rails.version.start_with? '5'
+  end
+  def migration_version
+    if rails5?
+      "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+    else
+      "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+      
+    end
+  end
+
 end

--- a/lib/generators/ratyrate/templates/average_cache_migration.rb
+++ b/lib/generators/ratyrate/templates/average_cache_migration.rb
@@ -1,4 +1,4 @@
-class CreateAverageCaches < ActiveRecord::Migration
+class CreateAverageCaches < ActiveRecord::Migration<%= migration_version %>
 
   def self.up
     create_table :average_caches do |t|

--- a/lib/generators/ratyrate/templates/cache_migration.rb
+++ b/lib/generators/ratyrate/templates/cache_migration.rb
@@ -1,4 +1,4 @@
-class CreateRatingCaches < ActiveRecord::Migration
+class CreateRatingCaches < ActiveRecord::Migration<%= migration_version %>
 
   def self.up
       create_table :rating_caches do |t|

--- a/lib/generators/ratyrate/templates/migration.rb
+++ b/lib/generators/ratyrate/templates/migration.rb
@@ -1,4 +1,4 @@
-class CreateRates < ActiveRecord::Migration
+class CreateRates < ActiveRecord::Migration<%= migration_version %>
 
   def self.up
       create_table :rates do |t|
@@ -9,7 +9,7 @@ class CreateRates < ActiveRecord::Migration
         t.timestamps
       end
 
-      add_index :rates, :rater_id
+      # add_index :rates, :rater_id
       add_index :rates, [:rateable_id, :rateable_type]
     end
 

--- a/lib/generators/ratyrate/templates/overall_average_migration.rb
+++ b/lib/generators/ratyrate/templates/overall_average_migration.rb
@@ -1,4 +1,4 @@
-class CreateOverallAverages < ActiveRecord::Migration
+class CreateOverallAverages < ActiveRecord::Migration<%= migration_version %>
 
   def self.up
     create_table :overall_averages do |t|


### PR DESCRIPTION
Added migration version to handle 'Directly inheriting from ActiveRecord::Migration is not supported" while running rails/rake db:migrate